### PR TITLE
Hi guys!

### DIFF
--- a/lib/fast_legs/base.js
+++ b/lib/fast_legs/base.js
@@ -6,7 +6,7 @@ function Base(client) {
 };
 
 Base.prototype.extend = function(obj) {
-  return _.extend(obj, FastLegS.Base);
+  return _.extend(obj, this);
 };
 
 Base.prototype.truncate = function(opts, callback) {

--- a/lib/fast_legs/statements.js
+++ b/lib/fast_legs/statements.js
@@ -150,7 +150,8 @@ var buildOrderClause = function(opts) {
       .map(function(orderField) {
         var direction  = orderField[0] === '-' ? "DESC" : "ASC";
         var orderField = orderField[0] === '-' ?
-          orderField.substring(1, orderField.length): orderField;
+          utils.doubleQuote(orderField.substring(1, orderField.length)) :
+          utils.doubleQuote(orderField);
         return orderField + " " + direction;
       })
       .join(', ')
@@ -167,12 +168,20 @@ var buildSelectFields = function(model, opts) {
     } else {
       return "*";
     }
-  } else {
+  } else if (_(opts.only).isArray()) {
     var columns = _(model._fields).pluck('column_name');
     var valid_fields = _.select(opts.only, function(valid_field) {
       return _.include(columns, valid_field);
     });
     return _(valid_fields).isEmpty() ? "*" : valid_fields.join(',');
+  } else {
+    var columns = _(model._fields).pluck('column_name');
+    var alias_fields = [];
+    _.map(opts.only, function(value, key) {
+      if (_.include(columns, key))
+        alias_fields.push(key+' AS '+utils.doubleQuote(value));
+    });
+    return _(alias_fields).isEmpty() ? "*" : alias_fields.join(', ');
   }
 };
 

--- a/lib/fast_legs/utils.js
+++ b/lib/fast_legs/utils.js
@@ -1,6 +1,24 @@
+var doubleQuote = exports.doubleQuote = function(value) {
+  if (nil(value)) {
+    return "NULL";
+  } else if (_(value).isNumber()) {
+    return value;
+  } else if (_(value).isArray()) {
+    return "(" + toCsv(value) + ")";
+  } else if (_(value).isDate()) {
+    return '"' + toDateTime(value) + '"';
+  } else {
+    return '"' + value + '"';
+  }
+};
+
 var fieldIsValid = exports.fieldIsValid = function(model, field) {
   var columns = _(model._fields).pluck('column_name');
   return _.include(columns, field.split('.')[0]);
+};
+
+var hasWhiteSpace = exports.hasWhiteSpace = function(value) {
+  return /\s/g.test(value);
 };
 
 var keysFromObject = exports.keysFromObject = function(fields) {

--- a/test/integration/integration_test.js
+++ b/test/integration/integration_test.js
@@ -1,6 +1,6 @@
 var helper = require('../test_helper.js')
   , fs = require('fs')
-  , logging = true;
+  , logging = false;
 
 module.exports = {
   'integrates': function() {
@@ -174,6 +174,31 @@ module.exports = {
           assert.eql(2, results.comments.length);
           callback(err, results);
         })
+      },
+      'find: find a post and return alias fields': function(callback) {
+        Post.find({ 'id': 1 }, {
+          only: {  'title'     : 'some_alias_title'
+                 , 'blurb'     : 'some_alias_blurb'
+                 , 'body'      : 'some_alias_body'
+                 , 'published' : 'some_alias_published'}
+        }, function(err, results) {
+          assert.eql(posts[0].title, results[0]['some_alias_title']);
+          assert.eql(posts[0].body, results[0]['some_alias_body']);
+          assert.eql(posts[0].published, results[0]['some_alias_published']);
+          assert.eql(posts[0].blurb, results[0]['some_alias_blurb']);
+          callback(err, results);
+        });
+      },
+      'find: find a post and order results descending using aliased columns': function(callback) {
+        Post.find([1,2], {
+          only: { 'title' : 'some_alias_title',
+                  'id'    : 'some id'},
+          order: ['-some id']
+        }, function(err, results) {
+          assert.eql(posts[1].id, results[0]['some id']);
+          assert.eql(posts[0].id, results[1]['some id']);
+          callback(err, results);
+        });
       },
       'update: new post title': function(callback) {
         Post.update({ 'title': 'Some Title 1' }, {

--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -1,6 +1,6 @@
 require.paths.unshift(__dirname + '/../..', __dirname + '/../support');
 
 var assert = global.assert = require('assert')
-  , FastLegS = global.FastLegS = require('FastLegS')
+  , FastLegS = global.FastLegS = require('../lib/fast_legs')
   , _ = global._ = require('underscore@1.1.4')
   , async = global.async = require('async@0.1.7');

--- a/test/unit/statements_test.js
+++ b/test/unit/statements_test.js
@@ -96,7 +96,7 @@ module.exports = {
       "WHERE name = 'awesome sauce' " +
       "AND email = 'joepancakes@email.com' " +
       "LIMIT 50 " +
-      "ORDER BY field ASC;"
+      "ORDER BY \"field\" ASC;"
     );
   },
   'select statement: order desc': function() {
@@ -114,7 +114,7 @@ module.exports = {
       "WHERE name = 'awesome sauce' " +
       "AND email = 'joepancakes@email.com' " +
       "LIMIT 50 " +
-      "ORDER BY field DESC;"
+      "ORDER BY \"field\" DESC;"
     );
   },
   'select statement: multiple order fields': function() {
@@ -132,7 +132,7 @@ module.exports = {
       "WHERE name = 'awesome sauce' " +
       "AND email = 'joepancakes@email.com' " +
       "LIMIT 50 " +
-      "ORDER BY field DESC, another_field ASC;"
+      "ORDER BY \"field\" DESC, \"another_field\" ASC;"
     );
   },
   'select statement: not equals (ne, not)': function() {
@@ -295,6 +295,54 @@ module.exports = {
       }, {}),
 
       "SELECT * FROM model_name WHERE INVALID;"
+    );
+  },
+  'select statement: column alias': function() {
+    assert.eql(
+      Statements.select(model, '2345', {
+        only: {'index':'a', 'email':'b'}
+      }),
+
+      "SELECT index AS \"a\", email AS \"b\" FROM model_name " +
+      "WHERE index = '2345';"
+    )
+  },
+  'select statment: column alias ignores invalid fields': function() {
+    assert.eql(
+      Statements.select(model, '2345', {
+        only: {'index':'a', 'email':'b', 'bad_field':'c', 'bad_field_2':'d'}
+      }),
+
+      "SELECT index AS \"a\", email AS \"b\" FROM model_name " +
+      "WHERE index = '2345';"
+    )
+  },
+  'select statment: column alias all invalid fields returns all fields': function() {
+    assert.eql(
+      Statements.select(model, '2345', {
+        only: {'bad_field':'c', 'bad_field_2':'d'}
+      }),
+
+      "SELECT * FROM model_name " +
+      "WHERE index = '2345';"
+    )
+  },
+  'select statement: column alias with order alias': function() {
+    assert.eql(
+      Statements.select(model, {
+        'name': 'awesome sauce',
+        'email': 'joepancakes@email.com'
+      }, {
+        only: {'index':'an index', 'email':'a email'},
+        limit: 50,
+        order: ['-an index', 'a email']
+      }),
+
+      "SELECT index AS \"an index\", email AS \"a email\" FROM model_name " +
+      "WHERE name = 'awesome sauce' " +
+      "AND email = 'joepancakes@email.com' " +
+      "LIMIT 50 " +
+      "ORDER BY \"an index\" DESC, \"a email\" ASC;"
     );
   },
 


### PR DESCRIPTION
So a couple of things were happening here:
1. Base was accessing itself via global.FastLegS instead of via itself
2. The problem was hidden during test runs because global.FastLegS was set in test_helper.js, so Base just used it
3. When installed with npm, test_helper.js initialized global.FastLegS via the installed package instead of its own source so the integration tests were not actually running against source.

Just made two minor changes to resolve the above:
1. changed FastLegS.Base to this in base.js
2. changed require('FastLegS') to require('../lib/fast_legs') in test_helper.js

Rock!
