### PR TITLE
Do not modify opts in base.js, these may be globals.

### DIFF
--- a/lib/fast_legs/base.js
+++ b/lib/fast_legs/base.js
@@ -22,6 +22,8 @@ Base.prototype.truncate = function(opts, callback) {
   if (typeof opts === 'function') {
     callback = opts;
     opts = {};
+  } else {
+    opts = _.clone(opts);
   }
 
   var truncateStatement = Statements.truncate(this, opts);
@@ -53,6 +55,9 @@ Base.prototype.create = function(obj, callback) {
       if (_.isFunction(opts)) {
         callback = opts;
         opts = {};
+      } else {
+        /* Do not modify opts, which may be global. */
+        opts = _.clone(opts);
       }
 
       if (finder === 'findOne') opts.limit = 1;


### PR DESCRIPTION
Modifying options passed to `findOne` and the like can be potentially dangerous. Here's an example:

```
# What to fetch for a radio
radiosParams =
  order   : [ "name" ]
  only    : [
    "id", "name", "token", "website",
    "title", "artist", "genre", "description",
    "longitude", "latitude"
  ]
  include : {
    streams : {
      only : [ "id", "format", "url", "msg" ]
    }
  }

@ Wrappers
getRadios = (param, fn) ->
  Radio.find param, radiosParams, fn

getRadio = (param, fn) ->
  Radio.findOne param, radiosParams, fn
```

In one call `getRadio` then all subsequent calls to `getRadios` have only one result, due to the fact that `limit: 1` gets added to `radiosParams`..
