### PR TITLE
Improved many-to-many support.

### DIFF
--- a/lib/fast_legs/base.js
+++ b/lib/fast_legs/base.js
@@ -49,12 +49,12 @@ Base.prototype.create = function(obj, callback) {
   Base.prototype[finder] = function(selector, opts, callback) {
     var self = this;
 
-    var findQuery = function() {
-      if (_.isFunction(opts)) {
-        callback = opts;
-        opts = {};
-      }
+    if (_.isFunction(opts)) {
+      callback = opts;
+      opts = {};
+    }
 
+    var findQuery = function() {
       if (finder === 'findOne') opts.limit = 1;
 
       var outValues = [];
@@ -96,7 +96,7 @@ Base.prototype.create = function(obj, callback) {
       });
     };
 
-    loadSchema(self, findQuery);
+    loadSchema(self, findQuery, opts);
   };
 });
 
@@ -158,9 +158,13 @@ var handleIncludes = function(self, models, selector, includes, callback) {
 
           if (relationship === 'many') {
             var primaryKeySelector = {};
-            if (includedModel.joinOn.split('.').length > 1) {
-              primaryKeySelector[includedModel[includeFinder].primaryKey] = model[self.primaryKey];
-              includes[includeFinder].join = includedModel.joinOn.split('.');
+            if (includedModel.assoc) {
+              var primaryKey = _(includedModel.assoc.foreignKeys).find(function (e) {
+                return e.model.tableName === self.tableName}).key;
+              primaryKeySelector[primaryKey] = model[self.primaryKey];
+              var linkKey = _.find(includedModel.assoc.foreignKeys, function (elem) {
+                return elem.model.tableName === includedModel[includeFinder].tableName}).key;
+              includes[includeFinder].join = { model: includedModel.assoc, key: linkKey}; 
             } else {
               primaryKeySelector[includedModel.joinOn] = model[self.primaryKey];
             }
@@ -218,13 +222,18 @@ var handleIncludes = function(self, models, selector, includes, callback) {
   }
 };
 
-var loadSchema = function(model, query) {
+var loadSchema = function(model, query, opts) {
+  if (_(opts).isUndefined())
+    opts = {};
+
   var statement = Statements.information(model);
 
   if (_(model._fields).isUndefined()) {
     model.client.emit('query', statement, function(err, result) {
       model._fields = result.rows;
-      query();
+      if (_(opts.join).isUndefined())
+        return query();
+      loadSchema(opts.join.model,query);
     });
   } else {
     query();

--- a/lib/fast_legs/statements.js
+++ b/lib/fast_legs/statements.js
@@ -92,9 +92,10 @@ var buildJoinClause = function(model, opts) {
   if (_(opts.join).isUndefined()) {
     return "";
   } else {
-    return  " INNER JOIN "  + opts.join[0] + " ON " +
+    model._fields = model._fields.concat(opts.join.model._fields);
+    return " INNER JOIN "  + opts.join.model.tableName + " ON " +
             '"' + model.tableName + '"' + "." + model.primaryKey + "=" +
-            opts.join[0]    + "." + opts.join[1];
+            opts.join.model.tableName + "." + opts.join.key;
   }
 };
 


### PR DESCRIPTION
This PR provides an enhanced many-to-many support. It works that way:

```
Foo = FastLegS.Base.extend
  tableName  : "foos"
  primaryKey : "id"

Bar = FastLegS.Base.extend
  tableName  : "bars"
  primaryKey : "id"

FooBar = FastLegS.Base.extend
  tableName   : "foos_bars"
  foreignKeys : {
    model : Foo,
    key   : "foo_id" }, {
    model : Bar,
    key   : "bar_id" } ]

Foo.many = [ {
    bars  : Bar,
    assoc : FooBar } ]

Bar.many = [ {
    foos  : Foo,
    assoc : FooBar } ]
```

The old `joinOn : "foo.bar_id"` is dropped.

Also. `includes.join` is changed. It is now:

```
Foo.find { id : id }, {
  includes : {
    join : {
      model : Bar,
      key   : "foo_id"
    }
  }
}, ...
```
