### PR TITLE
Fixes a null result object in the update method of Base

### DIFF
--- a/lib/fast_legs/base.js
+++ b/lib/fast_legs/base.js
@@ -107,6 +107,8 @@ Base.prototype.update = function(selector, obj, callback) {
     var outValues = [];
     var updateStatement = Statements.update(self, selector, obj, outValues);
     self.client.emit('query', updateStatement, outValues, function(err, result) {
+        // result is null if there's an error
+      result = result || {rowCount : 0};
       callback(err, result.rowCount);
     });
   };


### PR DESCRIPTION
Base.js defines the update method as follows:

Base.prototype.update = function(selector, obj, callback) {
  var self = this;

  var updateQuery = function() {
    var outValues = [];
    var updateStatement = Statements.update(self, selector, obj, outValues);
    self.client.emit('query', updateStatement, outValues, function(err, result) {
      callback(err, result.rowCount);
    });
  };

  loadSchema(self, updateQuery);
};

This breaks if the query has an error (which is paired with a null result), due to rowCount being called on a null object.

Updated code to define result if it doesn't already exist:

result = result || {rowCount:0};
