### PR TITLE
properly surface pg connection errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 .fastlegs
 node_modules
+.sublime-project
+.sublime-workspace

--- a/lib/fast_legs/client.js
+++ b/lib/fast_legs/client.js
@@ -13,18 +13,28 @@ var _ = require('underscore')._;
 function Client(connParams) {
   this.connParams = connParams;
   this.connected  = false;
+  this.lastError = null;
 };
 
 Client.prototype.__proto__ = EventEmitter.prototype;
 
 Client.prototype.connect = function() {
+  var self = this;
   this.client = new pg.Client(this.connParams);
+  this.client.on('error', function(err){
+    self.lastError = err;
+    return true;
+  });
   this.on('query', function(query, values, callback) {
-    if (!_.isUndefined(values[0])) values = _.flatten(values);
-    this.connected || this.doConnect();
-    this.client.query(query, values, function(err, result) {
-      callback(err, result);
-    });
+    if(self.lastError !== null){
+      callback(self.lastError,0);
+    }else{
+      if (!_.isUndefined(values[0])) values = _.flatten(values);
+      this.connected || this.doConnect();
+      this.client.query(query, values, function(err, result) {
+        callback(err, result);
+      });
+    }
   });
 }
 

--- a/lib/fast_legs/client.js
+++ b/lib/fast_legs/client.js
@@ -21,13 +21,17 @@ Client.prototype.__proto__ = EventEmitter.prototype;
 Client.prototype.connect = function() {
   var self = this;
   this.client = new pg.Client(this.connParams);
+  // if there are any problems w/ the pg client, record the error
   this.client.on('error', function(err){
     self.lastError = err;
     return true;
   });
   this.on('query', function(query, values, callback) {
+    // if there were any errors with the pg client, surface them here then clear
     if(self.lastError !== null){
-      callback(self.lastError,0);
+      var error = self.lastError;
+      self.lastError = null;
+      callback(error,0);
     }else{
       if (!_.isUndefined(values[0])) values = _.flatten(values);
       this.connected || this.doConnect();

--- a/test/integration/pg_connection.js
+++ b/test/integration/pg_connection.js
@@ -1,0 +1,10 @@
+var helper = require('../test_helper.js');
+var Client = require('../../lib/fast_legs/client');
+
+module.exports = {
+	'Surfaces error in the callback when pg connection fails' : function(){
+		var client = new Client();
+		client.connect();
+		client.emit('query', 'Select now();', function(err, result){ assert.isNotNull(err);});
+	}
+};


### PR DESCRIPTION
Currently, the FastLegS client does not properly handle the pg modules .on('error') emission, which results in a uncaughtException being thrown to the process if there's any burp in the DB connection.  

This patch adds an on('error') listener that records the error and surfaces it to the client's query callback as an error so the app can recover gracefully.
