### PR TITLE
Fix and tests for issue #37

### DIFF
--- a/lib/adapters/mysql/statements.js
+++ b/lib/adapters/mysql/statements.js
@@ -191,7 +191,7 @@ var buildOperator = function(key, value, outValues) {
 		' to_tsquery(\'english\', ' + utils.quote(outValues, operator) + ')';
   } else {
     return field + ' ' + 
-      ((operator === 'ILIKE')?'LIKE':operator) + ' ' + utils.quote(outValues, operator);
+      ((operator === 'ILIKE')?'LIKE':operator) + ' ' + utils.quote(outValues, operator, value);
   }
 };
 

--- a/lib/adapters/mysql/utils.js
+++ b/lib/adapters/mysql/utils.js
@@ -16,9 +16,9 @@ utils.backtick = function(field) {
  return field.indexOf(' ') >= 0 ? _str.surround(field, '`') : field;
 };
 
-utils.quote = function(outValues, operator) {
+utils.quote = function(outValues, operator, value) {
   if (operator === 'IN' || operator === 'NOT IN') {
-    var valuePos = _.range(1, outValues.length+1);
+    var valuePos = _.range(outValues.length - value.length + 1, outValues.length+1);
     var values = _.reduce(valuePos, function(memo, pos, i) {
       memo += '?'; 
       if (i+1 !== valuePos.length) memo += ',';

--- a/lib/adapters/pg/statements.js
+++ b/lib/adapters/pg/statements.js
@@ -185,7 +185,7 @@ var buildOperator = function(key, value, outValues) {
     return 'to_tsvector(\'english\', ' + field + ') ' + operator +
 		' to_tsquery(\'english\', ' + utils.quote(outValues, operator) + ')';
   } else {
-    return field + ' ' + operator + ' ' + utils.quote(outValues, operator);
+    return field + ' ' + operator + ' ' + utils.quote(outValues, operator, value);
   }
 };
 

--- a/lib/adapters/pg/utils.js
+++ b/lib/adapters/pg/utils.js
@@ -11,9 +11,9 @@ var Utils = require('../../utils');
 
 var utils = new Utils();
 
-utils.quote = function(outValues, operator) {
+utils.quote = function(outValues, operator, value) {
   if (operator === 'IN' || operator === 'NOT IN') {
-    var valuePos = _.range(1, outValues.length+1);
+    var valuePos = _.range(outValues.length - value.length + 1, outValues.length+1);
     var values = _.reduce(valuePos, function(memo, pos, i) {
       memo += '$' + pos.toString();
       if (i+1 !== valuePos.length) memo += ',';

--- a/test/unit/select/select_mysql.test.js
+++ b/test/unit/select/select_mysql.test.js
@@ -204,6 +204,8 @@ describe('Select statements mysql:', function() {
       .to.be("SELECT * FROM model_name WHERE field IN (?);");
     expect(StatementsMySQL.select(model, { 'field.in': ['some name', 34] }, {}, []))
       .to.be("SELECT * FROM model_name WHERE field IN (?,?);");
+    expect(StatementsMySQL.select(model, { 'age':7, 'field.in': ['some name', 34] }, {}, []))
+      .to.be("SELECT * FROM model_name WHERE age = ? AND field IN (?,?);");
   });
 
   it('not in a list of values (nin, not_in)', function() {
@@ -213,6 +215,8 @@ describe('Select statements mysql:', function() {
       .to.be("SELECT * FROM model_name WHERE field NOT IN (?,?);");
     expect(StatementsMySQL.select(model, { 'field.not_in': ['some name', 34] }, {}, []))
       .to.be("SELECT * FROM model_name WHERE field NOT IN (?,?);");
+    expect(StatementsMySQL.select(model, { 'age':7, 'field.not_in': ['some name', 34] }, {}, []))
+      .to.be("SELECT * FROM model_name WHERE age = ? AND field NOT IN (?,?);");
   });
 
   it('simple or', function() {

--- a/test/unit/select/select_pg.test.js
+++ b/test/unit/select/select_pg.test.js
@@ -203,6 +203,8 @@ describe('Select statements pg:', function() {
       .to.be("SELECT * FROM \"model_name\" WHERE field IN ($1);");
     expect(StatementsPg.select(model, { 'field.in': ['some name', 34] }, {}, []))
       .to.be("SELECT * FROM \"model_name\" WHERE field IN ($1,$2);");
+    expect(StatementsPg.select(model, { 'age': 7, 'field.in': ['some name', 34] }, {}, []))
+      .to.be("SELECT * FROM \"model_name\" WHERE age = $1 AND field IN ($2,$3);");
   });
 
   it('not in a list of values (nin, not_in)', function() {
@@ -212,6 +214,8 @@ describe('Select statements pg:', function() {
       .to.be("SELECT * FROM \"model_name\" WHERE field NOT IN ($1,$2);");
     expect(StatementsPg.select(model, { 'field.not_in': ['some name', 34] }, {}, []))
       .to.be("SELECT * FROM \"model_name\" WHERE field NOT IN ($1,$2);");
+    expect(StatementsPg.select(model, { 'age': 7, 'field.not_in': ['some name', 34] }, {}, []))
+      .to.be("SELECT * FROM \"model_name\" WHERE age = $1 AND field NOT IN ($2,$3);");
   });
 
   it('simple or', function() {


### PR DESCRIPTION
Bug: When an IN/NOT IN predicate is not the first to be added, the
statements.js:buildOperator function includes the whole outValues array
as values.

How to reproduce:
See the tests added. These will fail before this fix.

Fix:
The utils.js:quote function now takes the value being added as third
parameter. When quoting an IN/NOT IN operator, the valuePos array
starts at the correct index (outValues.length - value.length + 1).
