### PR TITLE
Allow passing arrays into node-postgres.

### DIFF
--- a/lib/adapters/pg/client.js
+++ b/lib/adapters/pg/client.js
@@ -34,7 +34,6 @@ Client.prototype.connect = function() {
       self.lastError = null;
       callback(error,0);
     }else{
-      if (!_.isUndefined(values[0])) values = _.flatten(values);
       self.connected || self.doConnect();
       self.client.query(query, values, callback);
     }

--- a/lib/adapters/pg/statements.js
+++ b/lib/adapters/pg/statements.js
@@ -179,8 +179,15 @@ var buildOperator = function(key, value, outValues) {
     var operator = "=";
   }
 
-  outValues.push(fixPgIssues(value));
-  outValues = _.flatten(outValues);
+  if (operator === 'IN' || operator === 'NOT IN') {
+    // Avoid flattening of the entire outValues here so we can pass arrays to
+    // the node-pg driver for usage as postgres arrays.
+    value.forEach(function(singleValue) {
+      outValues.push(fixPgIssues(singleValue));
+    });
+  } else {
+    outValues.push(fixPgIssues(value));
+  }
   if (key.split('.')[1] == 'textsearch') {
     return 'to_tsvector(\'english\', ' + field + ') ' + operator +
 		' to_tsquery(\'english\', ' + utils.quote(outValues, operator) + ')';

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "homepage": "https://github.com/didit-tech/FastLegS",
   "dependencies": {
     "async": "0.1.18",
-    "pg": "0.8.1",
+    "pg": "0.13.1",
     "mysql": "2.0.0-alpha3",
     "underscore": "1.4.3",
     "underscore.string": "2.3.1"


### PR DESCRIPTION
node-postgres now correctly handles arrays as query-parameters as of
brianc/node-postgres#278.
