### PR TITLE
Handling null value in 'not' and 'ne' operators

### DIFF
--- a/lib/adapters/mysql/statements.js
+++ b/lib/adapters/mysql/statements.js
@@ -142,6 +142,7 @@ var buildOperator = function(key, value, outValues) {
 
   switch(key.split('.')[1]) {
   case 'ne': case 'not':
+    if(value === null) return field + ' IS NOT NULL';
     var operator = "<>";
     break;
   case 'gt':

--- a/lib/adapters/pg/statements.js
+++ b/lib/adapters/pg/statements.js
@@ -139,6 +139,7 @@ var buildOperator = function(key, value, outValues) {
 
   switch(key.split('.')[1]) {
   case 'ne': case 'not':
+    if(value === null) return field + ' IS NOT NULL';
     var operator = "<>";
     break;
   case 'gt':

--- a/test/unit/select/select_mysql.test.js
+++ b/test/unit/select/select_mysql.test.js
@@ -153,6 +153,10 @@ describe('Select statements mysql:', function() {
       .to.be("SELECT * FROM model_name WHERE name <> ?;");
     expect(StatementsMySQL.select(model, { 'name.not': 'awesome sauce' }, {}, []))
       .to.be("SELECT * FROM model_name WHERE name <> ?;");
+    expect(StatementsMySQL.select(model, { 'name.ne': null }, {}, []))
+      .to.be("SELECT * FROM model_name WHERE name IS NOT NULL;");
+    expect(StatementsMySQL.select(model, { 'name.not': null }, {}, []))
+      .to.be("SELECT * FROM model_name WHERE name IS NOT NULL;");
   });
 
   it('greater than (gt)', function() {

--- a/test/unit/select/select_pg.test.js
+++ b/test/unit/select/select_pg.test.js
@@ -152,6 +152,10 @@ describe('Select statements pg:', function() {
       .to.be("SELECT * FROM \"model_name\" WHERE name <> $1;");
     expect(StatementsPg.select(model, { 'name.not': 'awesome sauce' }, {}, []))
       .to.be("SELECT * FROM \"model_name\" WHERE name <> $1;");
+    expect(StatementsPg.select(model, { 'name.ne': null }, {}, []))
+      .to.be("SELECT * FROM \"model_name\" WHERE name IS NOT NULL;");
+    expect(StatementsPg.select(model, { 'name.not': null }, {}, []))
+      .to.be("SELECT * FROM \"model_name\" WHERE name IS NOT NULL;");
   });
 
   it('greater than (gt)', function() {


### PR DESCRIPTION
Build "IS NOT NULL" clause when using 'ne' or 'not' operator with null value i.e.

``` javascript
User.find({"name.not": null})
# => SELECT * FROM \"users\" WHERE name IS NOT NULL;
```
